### PR TITLE
Initialize job sources with an empty dataframe

### DIFF
--- a/lib/remi/cucumber/business_rules.rb
+++ b/lib/remi/cucumber/business_rules.rb
@@ -112,6 +112,7 @@ module Remi::BusinessRules
     def add_job_source(name)
       raise "Unknown source #{name} for job" unless @job.methods.include? name.symbolize
       @job_sources.add_subject(name, @job.send(name.symbolize))
+      @job.send(name.symbolize).empty_stub_df
     end
 
     def add_job_target(name)

--- a/lib/remi/cucumber/data_source.rb
+++ b/lib/remi/cucumber/data_source.rb
@@ -14,10 +14,13 @@ module Remi
         end
       end
 
+      def empty_stub_df
+        self.df = Daru::DataFrame.new([], order: @fields.keys)
+      end
+
       def stub_df
-        wdf = Daru::DataFrame.new([], order: @fields.keys)
-        wdf.add_row(stub_row_array)
-        self.df = wdf
+        empty_stub_df
+        self.df.add_row(stub_row_array)
       end
 
       def stub_values


### PR DESCRIPTION
This was causing problems when writing tests for jobs that connected to
databases but weren't explicitly used in a scenario.
