### PR TITLE
Add step that allows one to append data to an example.

### DIFF
--- a/features/examples.feature
+++ b/features/examples.feature
@@ -47,3 +47,17 @@ Feature: This tests the creation of example records.
     And the target has 3 records where 'Quantity' is greater than 0.9
     And the target has 3 records where 'Quantity' is between 0 and 1
     And the target has 2 records where 'Quantity' is between 0.6 and 2
+
+
+
+  Scenario: Adding data to a source that already has example data.
+    Given the following example for 'Source Data':
+      | Id | Name  |
+      | 1  | Alpha |
+      | 2  | Beta  |
+      | 3  | Gamma |
+    And the following records are appended to 'Source Data':
+      | Id | Name    |
+      | 4  | Delta   |
+      | 5  | Epsilon |
+    Then the target has 5 records

--- a/features/step_definitions/remi_step.rb
+++ b/features/step_definitions/remi_step.rb
@@ -15,15 +15,15 @@ Given /^the job target '([[:alnum:]\s\-_]+)'$/ do |arg|
   @brt.add_job_target arg
 end
 
-Given /^the following example(?: record| records|) called '([[:alnum:]\s\-_]+)':$/ do |arg, example_table|
-  @brt.add_example arg, example_table
-end
-
 Given /^the job parameter '([[:alnum:]\s\-_]+)' is "([^"]*)"$/ do |param, value|
   @brt.set_job_parameter(param, value)
 end
 
 ### Setting up example data
+
+Given /^the following example(?: record| records|) called '([[:alnum:]\s\-_]+)':$/ do |arg, example_table|
+  @brt.add_example arg, example_table
+end
 
 Given /^the following example(?: record| records|) for '([[:alnum:]\s\-_]+)':$/ do |source_name, example_table|
   example_name = source_name
@@ -35,6 +35,11 @@ Given /^the example '([[:alnum:]\s\-_]+)' for '([[:alnum:]\s\-_]+)'$/ do |exampl
   @brt.job_sources[source_name].stub_data_with(@brt.examples[example_name])
 end
 
+Given /^the following (?:record is|records are) appended to '([[:alnum:]\s\-_]+)':$/ do |source_name, example_table|
+  example_name = SecureRandom.uuid
+  @brt.add_example example_name, example_table
+  @brt.job_sources[source_name].append_data_with(@brt.examples[example_name])
+end
 
 ### Source file processing
 

--- a/lib/remi/cucumber/business_rules.rb
+++ b/lib/remi/cucumber/business_rules.rb
@@ -285,9 +285,17 @@ module Remi::BusinessRules
       @data_obj.stub_df if @data_obj.respond_to? :stub_df
     end
 
+    def example_to_df(example)
+      example.to_df(@data_obj.df.row[0].to_hash, field_symbolizer: @data_obj.field_symbolizer)
+    end
+
     def stub_data_with(example)
       stub_data
-      @data_obj.df = example.to_df(@data_obj.df.row[0].to_hash, field_symbolizer: @data_obj.field_symbolizer)
+      @data_obj.df = example_to_df(example)
+    end
+
+    def append_data_with(example)
+      @data_obj.df = @data_obj.df.concat example_to_df(example)
     end
 
 


### PR DESCRIPTION
This is convenient for when you have one base example table
defined in a background step and you need to add different
data records to it in different scenarios.
