### PR TITLE
FIX - Time objects were being treated as arrays when passed to parse_date

### DIFF
--- a/lib/remi/cucumber/data_source.rb
+++ b/lib/remi/cucumber/data_source.rb
@@ -23,7 +23,7 @@ module Remi
           float:    ->() { Faker::Number.decimal(2,2) },
           integer:  ->() { Faker::Number.number(4) },
           date:     ->() { Faker::Date.backward(3650) },
-          datetime: ->() { Faker::Time.backward(3650) },
+          datetime: ->() { Faker::Time.backward(3650).to_datetime },
           boolean:  ->() { ['T','F'].shuffle.first }
         })
       end


### PR DESCRIPTION
Converting them to a DateTime resolves the issue
