### PR TITLE
Replace "Today's Date" references in tests with date formatting formulas

### DIFF
--- a/features/sample_job.feature
+++ b/features/sample_job.feature
@@ -195,12 +195,12 @@ Feature: This is a sample feature file.
     Then the target field '<Target Field>' is populated from the source field using the format "<Target Format>"
 
     When the source field is blank
-    Then the target field '<Target Field>' is populated with "<If Blank>" using the format "<Target Format>"
+    Then the target field '<Target Field>' is populated with "<If Blank>"
 
     Examples:
-      | Source Field | Source Format | Target Field    | Target Format | If Blank       |
-      | Applied Date | %m/%d/%Y      | Applied_Date__c | %Y-%m-%d      | *Today's Date* |
-      | Birthdate    | %m/%d/%Y      | Birthdate       | %Y-%m-%d      |                |
+      | Source Field | Source Format | Target Field    | Target Format | If Blank           |
+      | Applied Date | %m/%d/%Y      | Applied_Date__c | %Y-%m-%d      | *Today: %Y-%m-%d*  |
+      | Birthdate    | %m/%d/%Y      | Birthdate       | %Y-%m-%d      |                    |
 
 
   Scenario: Populating School__c

--- a/features/step_definitions/remi_step.rb
+++ b/features/step_definitions/remi_step.rb
@@ -327,17 +327,6 @@ Then /^the target field '(.+)' is populated from the source field using the form
   expect(@brt.target.field.value).to eq source_reformatted
 end
 
-Then /^the target field '(.+)' is populated with "([^"]*)" using the format "([^"]*)"$/ do |target_field, target_value, target_format|
-  source_format = @brt.source.field.metadata[:format]
-  target_value_source_format = target_value == "*Today's Date*" ? Date.today.strftime(source_format) : target_value
-  target_reformatted = Remi::Transform[:format_date].(from_fmt: source_format, to_fmt: target_format)
-   .call(target_value_source_format)
-
-  step "the target field '#{target_field}'"
-  @brt.run_transforms
-  expect(@brt.target.field.value).to eq target_reformatted
-end
-
 Then /^the target field '(.+)' is the first non-blank value from source fields '(.+)'$/ do |target_field_name, source_field_list|
   source_fields = "'#{source_field_list}'".split(',').map do |field_with_quotes|
     full_field_name = field_with_quotes.match(/'(.+)'/)[1]


### PR DESCRIPTION
This was a hack to begin with, so it's being replaced with a more flexible solution.
