### PR TITLE
Refactored step logic for multiple source-target tests

### DIFF
--- a/features/formulas.feature
+++ b/features/formulas.feature
@@ -72,4 +72,5 @@ Feature: This tests the creation of example records.
     And the source field 'Some Date'
     And the source field 'Some String'
     And the target field 'Combination'
-    Then the target field is a concatenation of 'Some Date' and 'Some String', delimited by "-"
+    Then the target field 'Combination' is a concatenation of the source fields 'Some Date' and 'Some String', delimited by "-"
+    Then the target field 'Combination' is a concatenation of the source fields, delimited by "-"

--- a/features/sample_job.feature
+++ b/features/sample_job.feature
@@ -198,9 +198,9 @@ Feature: This is a sample feature file.
     Then the target field '<Target Field>' is populated with "<If Blank>"
 
     Examples:
-      | Source Field | Source Format | Target Field    | Target Format | If Blank           |
-      | Applied Date | %m/%d/%Y      | Applied_Date__c | %Y-%m-%d      | *Today: %Y-%m-%d*  |
-      | Birthdate    | %m/%d/%Y      | Birthdate       | %Y-%m-%d      |                    |
+      | Source Field | Source Format | Target Field    | Target Format | If Blank          |
+      | Applied Date | %m/%d/%Y      | Applied_Date__c | %Y-%m-%d      | *Today: %Y-%m-%d* |
+      | Birthdate    | %m/%d/%Y      | Birthdate       | %Y-%m-%d      |                   |
 
 
   Scenario: Populating School__c


### PR DESCRIPTION
This commit includes many changes to the under-the-hood
step logic that makes many steps more flexible when
using single or full-field notation.
