### PR TITLE
Support for extracting multiple csv files

### DIFF
--- a/lib/remi/extractor/sftp_file.rb
+++ b/lib/remi/extractor/sftp_file.rb
@@ -2,12 +2,20 @@ module Remi
   module Extractor
 
     class LocalFile
-      def initialize(path)
+      def initialize(path:, folder: nil)
         @path = path
+        @folder = folder
       end
 
       def extract
-        @path
+        if @folder
+          Dir.entries(@folder).map do |entry|
+            next unless entry.match(@path)
+            File.join(@folder,entry)
+          end.compact
+        else
+          @path
+        end
       end
     end
 
@@ -15,22 +23,39 @@ module Remi
 
       class FileNotFoundError < StandardError; end
 
-      def initialize(credentials:, remote_file:, remote_folder: '', local_folder: Settings.work_dir, port: '22', most_recent_only: false, logger: Remi::Settings.logger)
+      SortDesc = Struct.new(:value) do
+        def <=> (target)
+          -(self.value <=> target.value)
+        end
+      end
+
+      def initialize(credentials:, remote_file:, remote_folder: '', local_folder: Settings.work_dir, port: nil, most_recent_only: false, group_by: nil, most_recent_by: :createtime, logger: Remi::Settings.logger)
         @credentials = credentials
         @remote_file = remote_file
         @remote_folder = remote_folder
         @local_folder = local_folder
-        @port = port
+        @port = port || (credentials && credentials[:port]) || '22'
         @most_recent_only = most_recent_only
+        @group_by = group_by
+        @most_recent_by = most_recent_by
         @logger = logger
       end
 
       attr_reader :logger
 
       def extract
-        to_download = @most_recent_only ? Array(most_recent_entry(matching_entries)) : matching_entries
         raise FileNotFoundError, "File not found: #{@remote_file}" if to_download.size == 0
         download(to_download)
+      end
+
+      def to_download
+        if @group_by
+          most_recent_in_group
+        elsif @most_recent_only
+          Array(most_recent_entry(matching_entries))
+        else
+          matching_entries
+        end
       end
 
       def all_entries(remote_folder = @remote_folder)
@@ -42,15 +67,41 @@ module Remi
       end
 
       def most_recent_entry(entries = matching_entries)
-        entries.sort_by { |e| e.attributes.createtime }.reverse!.first
+        entries.sort_by { |e| sort_files_by(e) }.reverse!.first
       end
 
-      def download(to_download = matching_entries, local_folder: @local_folder, ntry: 3)
+      def sort_files_by(entry)
+        if @most_recent_by == :filename
+          entry.name
+        else
+          entry.attributes.send(@most_recent_by)
+        end
+      end
+
+      def most_recent_in_group(match_group = @group_by)
+        entries_with_group = matching_entries.map do |entry|
+          match = entry.name.match(match_group)
+          next unless match
+
+          group = match.to_a[1..-1]
+          { group: group, entry: entry }
+        end.compact
+        entries_with_group.sort_by! { |e| [e[:group], SortDesc.new(sort_files_by(e[:entry]))] }
+
+        last_group = nil
+        entries_with_group.map do |entry|
+          next unless entry[:group] != last_group
+          last_group = entry[:group]
+          entry[:entry]
+        end.compact
+      end
+
+      def download(entries_to_download, remote_folder: @remote_folder, local_folder: @local_folder, ntry: 3)
         connection do |sftp|
-          to_download.map do |entry|
+          entries_to_download.map do |entry|
             local_file = File.join(local_folder, entry.name)
             @logger.info "Downloading #{entry.name} to #{local_file}"
-            retry_download(ntry) { sftp.download!(entry.name, local_file) }
+            retry_download(ntry) { sftp.download!(File.join(remote_folder, entry.name), local_file) }
             local_file
           end
         end
@@ -71,6 +122,7 @@ module Remi
         1.upto(ntry).each do |itry|
           begin
             block.call
+            break
           rescue RuntimeError => err
             raise err unless itry < ntry
             @logger.error "Download failed with error: #{err.message}"

--- a/lib/remi/refinements/daru.rb
+++ b/lib/remi/refinements/daru.rb
@@ -13,15 +13,23 @@ module Remi
           dupdf
         end
 
-        # Public: Fixes a bug where the dataframe on the left side of the
-        # concatenation is accidentally modified.
+        # Public: Allows for combining dataframes with different columns
         def concat other_df
-          vectors = []
-          @vectors.each do |v|
-            vectors << self[v].dup.to_a.concat(other_df[v].to_a)
+          vectors = @vectors.to_a
+          data = []
+
+          vectors.each do |v|
+            other_vec = other_df.vectors.include?(v) ? other_df[v].to_a : [nil] * other_df.size
+            data << self[v].dup.to_a.concat(other_vec)
           end
 
-          ::Daru::DataFrame.new(vectors, order: @vectors)
+          other_df.vectors.each do |v|
+            next if vectors.include?(v)
+            vectors << v
+            data << ([nil] * self.size).concat(other_df[v].to_a)
+          end
+
+          ::Daru::DataFrame.new(data, order: vectors)
         end
 
         # Public: Saves a Dataframe to a file.

--- a/spec/extractor/sftp_file_spec.rb
+++ b/spec/extractor/sftp_file_spec.rb
@@ -1,0 +1,125 @@
+require 'remi_spec'
+
+describe Extractor::SftpFile do
+  before do
+    now = Time.new
+
+    example_files = [
+      { name: "ApplicantsA-9.csv", createtime: now - 10.minutes },
+      { name: "ApplicantsA-3.csv", createtime: now - 5.minutes },
+      { name: "ApplicantsA-5.csv", createtime: now - 1.minutes },
+      { name: "ApplicantsB-7.csv", createtime: now - 10.minutes },
+      { name: "ApplicantsB-6.csv", createtime: now - 5.minutes },
+      { name: "ApplicantsB-2.csv", createtime: now - 1.minutes },
+      { name: "ApplicantsB-2.txt", createtime: now - 0.minutes },
+      { name: "Apples.csv", createtime: now - 1.minutes },
+    ]
+
+    allow_any_instance_of(Extractor::SftpFile).to receive(:all_entries) do
+      example_files.map do |file|
+        Net::SFTP::Protocol::V04::Name.new(
+          file[:name],
+          Net::SFTP::Protocol::V04::Attributes.new(createtime: file[:createtime])
+        )
+      end
+    end
+
+    @params = { credentials: nil }
+  end
+
+  let(:sftpfile) { Extractor::SftpFile.new(**@params) }
+
+
+
+
+  context 'extracting all files matching a pattern' do
+    before do
+      @params[:remote_file] = /ApplicantsA-\d+\.csv/
+    end
+
+    it 'does not extract non-matching files' do
+      expect(sftpfile.to_download.map(&:name)).not_to include "Apples.csv"
+    end
+
+    it 'extracts all matching files' do
+      expect(sftpfile.to_download.map(&:name)).to match_array([
+       "ApplicantsA-9.csv",
+       "ApplicantsA-3.csv",
+       "ApplicantsA-5.csv"
+      ])
+    end
+  end
+
+
+  context 'extracting only the most recent matching a pattern' do
+    before do
+      @params.merge!({
+        remote_file: /ApplicantsA-\d+\.csv/,
+        most_recent_only: true
+      })
+    end
+
+    it 'extracts only the most recent matching file' do
+      expect(sftpfile.to_download.map(&:name)).to match_array([
+       "ApplicantsA-5.csv"
+      ])
+    end
+
+    context 'using filename instead of createtime' do
+      before do
+        @params[:most_recent_by] = :filename
+      end
+
+      it 'extracts only the most recent matching file' do
+        expect(sftpfile.to_download.map(&:name)).to match_array([
+         "ApplicantsA-9.csv"
+        ])
+      end
+    end
+  end
+
+
+  context 'extracting files matching a pattern with a by group' do
+    before do
+      @params.merge!({
+        credentials: nil,
+        remote_file: /^Applicants(A|B)-\d+\.csv/,
+        group_by: /^Applicants(A|B)/
+      })
+    end
+
+    it 'extracts the most recent file that matches a particular regex' do
+      expect(sftpfile.to_download.map(&:name)).to match_array([
+       "ApplicantsA-5.csv",
+       "ApplicantsB-2.csv"
+      ])
+    end
+
+    context 'with a minimally selective pre-filter' do
+      before do
+        @params[:remote_file] = /^Applicants/
+      end
+
+      it 'extracts the most recent file that matches a particular regex' do
+        expect(sftpfile.to_download.map(&:name)).to match_array([
+         "ApplicantsA-5.csv",
+         "ApplicantsB-2.txt"
+        ])
+      end
+    end
+
+    context 'using filename instead of createtime' do
+      before do
+        @params[:most_recent_by] = :filename
+      end
+
+      it 'extracts only the most recent matching file' do
+        expect(sftpfile.to_download.map(&:name)).to match_array([
+         "ApplicantsA-9.csv",
+         "ApplicantsB-7.csv"
+        ])
+      end
+    end
+
+  end
+end

--- a/spec/remi_spec.rb
+++ b/spec/remi_spec.rb
@@ -1,0 +1,8 @@
+File.expand_path(File.join(File.dirname(__FILE__),'../lib')).tap {|pwd| $LOAD_PATH.unshift(pwd) unless $LOAD_PATH.include?(pwd)}
+
+require 'rubygems'
+require 'bundler/setup'
+
+require 'remi'
+
+include Remi


### PR DESCRIPTION
- Allows one to specify a group_by option to get the most recent file
  by group.
- Allows one to use the name of the file instead of the create time
  for selecting the most recent file.
- Added specs for extracting files from an sftp.
- Refined Daru::DataFrame.concatenate to support concatenating
  dataframes with different columns.
