### PR TITLE
MISC - Disables all default CSV conversions.

### DIFF
--- a/lib/remi/data_source/csv_file.rb
+++ b/lib/remi/data_source/csv_file.rb
@@ -9,6 +9,7 @@ module Remi
         CSV::DEFAULT_OPTIONS.merge({
           headers: true,
           header_converters: Remi::FieldSymbolizers[:standard],
+          converters: [],
           col_sep: ',',
           encoding: 'UTF-8',
           quote_char: '"'


### PR DESCRIPTION
This is way too risky when we have the possibility of leading zeroes and other things.
We'll need to develop a way to do error handling and such on conversions.
