### PR TITLE
Job files now get loaded in the constructor of business rule tester

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,6 +6,7 @@ require 'remi'
 require 'remi/cucumber'
 
 Remi::Settings.log_level = Logger::ERROR
+Remi::Settings.jobs_dir = File.join(__dir__, '../../jobs')
 
 Before do
   # Restart the random number generator prior to each scenario to

--- a/lib/remi/cucumber/business_rules.rb
+++ b/lib/remi/cucumber/business_rules.rb
@@ -113,6 +113,7 @@ module Remi::BusinessRules
 
     def initialize(job_name)
       job_class_name = "#{job_name.gsub(/\s/,'')}Job"
+      require_job_file(job_class_name)
       @job = Object.const_get(job_class_name).new
 
       @job_sources = DataSubjectCollection.new
@@ -129,6 +130,13 @@ module Remi::BusinessRules
     attr_reader :sources
     attr_reader :targets
     attr_reader :examples
+
+    def require_job_file(job_class_name)
+      job_file = Dir["#{Remi::Settings.jobs_dir}/**/*_job.rb"].map do |fname|
+        fname if File.basename(fname) == "#{job_class_name.underscore}.rb"
+      end.compact.pop
+      require job_file
+    end
 
     def add_job_source(name)
       raise "Unknown source #{name} for job" unless @job.methods.include? name.symbolize

--- a/lib/remi/settings.rb
+++ b/lib/remi/settings.rb
@@ -10,6 +10,14 @@ module Remi
       @work_dir = arg
     end
 
+    def jobs_dir
+      @jobs_dir ||= Pathname.new('jobs').realpath
+    end
+
+    def jobs_dir=(arg)
+      @jobs_dir = Pathname.new(arg).realpath
+    end
+
     def log_level
       @log_level ||= Logger::INFO
     end


### PR DESCRIPTION
We no longer need to load all jobs before running tests, just the ones
that are being tested.  This also allows us to mock operations that
happen when the class file is loaded (such as job parameters that
are pulled from an external system).
