### PR TITLE
Sub job execute and load no longer explicitly required

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,13 +123,13 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk (~> 2.3)
   daru (= 0.1.4.1)!
-  github-markup
+  github-markup (~> 1.4)
   iruby (= 0.2.7)
-  redcarpet
+  redcarpet (~> 3.3)
   remi!
   restforce (~> 2.1)
   salesforce_bulk_api!
-  yard
+  yard (~> 0.9)
 
 BUNDLED WITH
    1.11.2

--- a/jobs/sub_job_example_job.rb
+++ b/jobs/sub_job_example_job.rb
@@ -73,14 +73,14 @@ class SubJobExampleJob < Remi::Job
   target :zombified_beers
 
   transform :zombification do
-    # Sub jobs must be executed before their sources are available
-    beers_job.execute
+    # Sub jobs are executed when data from a sub job is requested
+    # Here, the sub job beers_job is executed
     just_beers.df = beer_fridge.df
 
-    # Sub job targets must be loaded before they are available to subjobs
+    # Data is supplied to the sub job on assignment
     beers_to_zombify.df = just_beers.df
-    beers_to_zombify.load
-    zombify_job.execute
+
+    # Here, the sub job zombify_job is executed using the data supplied to it above
     zombified_beers.df = zombie_fridge.df
   end
 end

--- a/lib/remi/data_subject.rb
+++ b/lib/remi/data_subject.rb
@@ -64,6 +64,7 @@ module Remi
 
     # @return [Remi::DataFrame] the dataframe associated with this DataSubject
     def df
+      dsl_eval
       @dataframe ||= Remi::DataFrame.create(df_type, [], order: fields.keys)
     end
 
@@ -71,6 +72,7 @@ module Remi
     # @param new_dataframe [Object] The new dataframe object to be associated.
     # @return [Remi::DataFrame] the associated dataframe
     def df=(new_dataframe)
+      dsl_eval
       if new_dataframe.respond_to? :df_type
         @dataframe = new_dataframe
       else
@@ -269,7 +271,7 @@ module Remi
     # @return [true] if successful
     def load
       return nil if @loaded || df.size == 0
-      dsl_eval if @block
+      dsl_eval
 
       load!
       @loaded = true
@@ -282,6 +284,12 @@ module Remi
     def load!
       loaders.each { |l| l.load encoded_dataframe }
       true
+    end
+
+    def df=(new_dataframe)
+      super
+      loaders.each { |l| l.load encoded_dataframe if l.autoload }
+      df
     end
 
     private

--- a/lib/remi/data_subjects/sub_job.rb
+++ b/lib/remi/data_subjects/sub_job.rb
@@ -11,6 +11,7 @@ module Remi
     attr_accessor :sub_job, :data_subject
 
     def extract
+      sub_job.execute
       sub_job.job.send(data_subject).df
     end
 
@@ -37,6 +38,10 @@ module Remi
     # @return [true] On success
     def load(data_frame)
       sub_job.job.send(data_subject).df = data_frame
+      true
+    end
+
+    def autoload
       true
     end
 

--- a/lib/remi/job.rb
+++ b/lib/remi/job.rb
@@ -271,7 +271,8 @@ module Remi
         "  parameters: #{params.to_h.keys}\n" +
         "  sources: #{sources}\n" +
         "  targets: #{targets}\n" +
-        "  transforms: #{transforms}"
+        "  transforms: #{transforms}\n" +
+        "  sub_jobs: #{sub_jobs}"
     end
 
 
@@ -282,6 +283,7 @@ module Remi
     # @return [self]
     def execute(*components)
       execute_transforms if components.empty? || components.include?(:transforms)
+      execute_sub_jobs if components.empty? || components.include?(:sub_jobs)
       execute_load_targets if components.empty? || components.include?(:load_targets)
       self
     end
@@ -331,6 +333,12 @@ module Remi
     # Loads all targets defined
     def execute_load_targets
       targets.each { |t| send(t).load }
+      self
+    end
+
+    # Executes all subjobs (not already executed)
+    def execute_sub_jobs
+      sub_jobs.each { |sj| send(sj).execute }
       self
     end
 

--- a/lib/remi/job/sub_job.rb
+++ b/lib/remi/job/sub_job.rb
@@ -24,7 +24,13 @@ module Remi
       end
 
       def execute
-        job.execute
+        execute! unless @executed
+      end
+
+      def execute!
+        result = job.execute
+        @executed = true
+        result
       end
 
       def execute_transforms

--- a/lib/remi/loader.rb
+++ b/lib/remi/loader.rb
@@ -18,5 +18,11 @@ module Remi
       raise NoMethodError, "#{__method__} not defined for #{self.class.name}"
     end
 
+    # If autoload is set to true, then any loaders are called at the moment
+    # a dataframe is assigned to a target (e.g., `my_target.df = some_df` will
+    # call `#load` on any loaders associated with `my_target`).
+    def autoload
+      false
+    end
   end
 end

--- a/spec/data_subject_spec.rb
+++ b/spec/data_subject_spec.rb
@@ -378,7 +378,6 @@ describe DataTarget do
       end
     end
 
-
     context '#field_symbolizer' do
       context 'field_symbolizer called before encoder' do
         let(:before_encoder) do
@@ -503,6 +502,23 @@ describe DataTarget do
         data_target.load!
         data_target.load!
       end
+    end
+  end
+
+  context '#df=' do
+    before do
+      data_target.encoder my_encoder
+      data_target.loader my_loader
+      data_target.loader my_loader2
+
+      allow(my_loader).to receive(:autoload) { false }
+      allow(my_loader2).to receive(:autoload) { true }
+    end
+
+    it 'loads any loaders set to autoload' do
+      expect(my_loader).not_to receive :load
+      expect(my_loader2).to receive :load
+      data_target.df = Remi::DataFrame::Daru.new([])
     end
   end
 end

--- a/spec/data_subjects/sub_job_spec.rb
+++ b/spec/data_subjects/sub_job_spec.rb
@@ -19,6 +19,12 @@ describe 'sub jobs' do
       allow(sub_job.job.sub_target).to receive(:df) { 'sub target df' }
       expect(extractor.extract).to eq 'sub target df'
     end
+
+    it 'executes the sub job when data is requested' do
+      expect(sub_job).to receive(:execute).once
+      extractor.extract
+    end
+
   end
 
   describe Loader::SubJob do
@@ -28,6 +34,10 @@ describe 'sub jobs' do
       some_data_frame = Daru::DataFrame.new({ a: [1,2,3] })
       loader.load(some_data_frame)
       expect(sub_job.job.sub_source.df).to eq some_data_frame
+    end
+
+    it 'autoloads the target' do
+      expect(loader.autoload).to be true
     end
   end
 end


### PR DESCRIPTION
Writing specs for real jobs became problematic when #execute
and #load needed to be called, because they might request
access to live data in the sub job without being appropriately stubbed out.

This commit makes #execute and #load happen implicitly, whenever
data is requested or assigned from/to a sub job data subject.