### PR TITLE
Resolve a bug with parsing google sheet data

### DIFF
--- a/lib/remi/data_subjects/gsheet.rb
+++ b/lib/remi/data_subjects/gsheet.rb
@@ -57,6 +57,7 @@ module Remi
       @data                                   = []
 
       entries.each do |file|
+        logger.info "Extracting Google Sheet data from #{file.pathname}"
         response = get_spreadsheet_vals(service, file.raw)
         data.push(response)
       end
@@ -111,25 +112,23 @@ module Remi
   class Parser::Gsheet < Parser
 
     def parse(gs_extract)
-      google_vals = gs_extract.data
       return_hash = nil
-      google_vals.each do |google_val|
+      gs_extract.data.each do |gs_data|
 
         if return_hash.nil?
           return_hash = Hash.new
-          google_val.values[0].each do |header|
+          gs_data.values[0].each do |header|
             return_hash[field_symbolizer.call(header)] = []
           end
         end
 
-        keys_temp = return_hash.keys
+        headers = return_hash.keys
+        header_idx = headers.each_with_index.to_h
 
-        google_val.values[1..-1].each do |rows|
-          col_num = 0
-
-          rows.each do |value|
-            return_hash[keys_temp[col_num]] << value
-            col_num +=1
+        gs_data.values[1..-1].each do |row|
+          headers.each do |header|
+            idx = header_idx[header]
+            return_hash[header] << (idx < row.size ? row[idx] : nil)
           end
         end
       end

--- a/spec/data_subjects/gsheet_spec.rb
+++ b/spec/data_subjects/gsheet_spec.rb
@@ -109,7 +109,9 @@ describe Parser::Gsheet do
   let(:gs_extract) { double('gs_extract') }
   let(:example_data) do
     [{"headers" => ["header_1", "header_2", "header_3"],
-      "row 1"   => ["value 1", "value 2", "value 3"]
+      "row 1"   => ["value 11", "value 12", "value 13"],
+      "row 2"   => ["value 21", "value 22", "value 23"],
+      "row 3"   => ["value 31", "value 32", "value 33"],
     }]
   end
 
@@ -123,11 +125,21 @@ describe Parser::Gsheet do
 
   it 'converted data into the correct dataframe' do
     expected_df = Daru::DataFrame.new(
-      :header_1 => ['value 1'],
-      :header_2 => ['value 2'],
-      :header_3 => ['value 3'],
+      :header_1 => ['value 11', 'value 21', 'value 31'],
+      :header_2 => ['value 12', 'value 22', 'value 32'],
+      :header_3 => ['value 13', 'value 23', 'value 33']
     )
     expect(parser.parse(gs_extract).to_a).to eq expected_df.to_a
   end
 
+  it 'works when the last column contains blanks' do
+    # Google API only returns an array of dimensions up to the last non-blank column
+    example_data[0]['row 2'].pop
+    expected_df = Daru::DataFrame.new(
+      :header_1 => ['value 11', 'value 21', 'value 31'],
+      :header_2 => ['value 12', 'value 22', 'value 32'],
+      :header_3 => ['value 13', nil,        'value 33']
+    )
+    expect(parser.parse(gs_extract).to_a).to eq expected_df.to_a
+  end
 end


### PR DESCRIPTION
When the last cell of a row was blank, all populated rows below that
in the same column were being shifted up.  This is a consequence of
the google sheet API returning a row as an array that has a size up
to the last populated column in a row.