### PR TITLE
FIX - Implement various SF loader fixes

### DIFF
--- a/lib/remi/data_subjects/salesforce.rb
+++ b/lib/remi/data_subjects/salesforce.rb
@@ -189,7 +189,7 @@ module Remi
       elsif @operation == :upsert
         Remi::SfBulkHelper::SfBulkUpsert.upsert(restforce_client, @sfo, data, batch_size: @batch_size, external_id: @external_id, logger: logger)
       elsif @operation == :delete
-        Remi::SfBulkHelper::SfBulkDelete.upsert(restforce_client, @sfo, data, batch_size: @batch_size, logger: logger)
+        Remi::SfBulkHelper::SfBulkDelete.delete(restforce_client, @sfo, data, batch_size: @batch_size, logger: logger)
       else
         raise ArgumentError, "Unknown operation: #{@operation}"
       end

--- a/lib/remi/data_subjects/salesforce_soap.rb
+++ b/lib/remi/data_subjects/salesforce_soap.rb
@@ -79,7 +79,8 @@ module Remi
           end
 
           merge_id = Array(row.delete(@merge_id_field))
-          soapforce_client.merge(@sfo, row, merge_id)
+          merge_row = row.select { |_, v| !v.blank? }
+          soapforce_client.merge!(@sfo, merge_row, merge_id)
         end
       else
         raise ArgumentError, "Unknown soap operation: #{@operation}"

--- a/spec/data_subjects/salesforce_soap_spec.rb
+++ b/spec/data_subjects/salesforce_soap_spec.rb
@@ -45,7 +45,7 @@ describe Loader::SalesforceSoap do
       { Id: '1234', Custom__c: 'something', Merge_Id: '5678' }
     ]
 
-    expect(soapforce_client).to receive(:merge) do
+    expect(soapforce_client).to receive(:merge!) do
       [
         :Contact,
         {
@@ -65,7 +65,25 @@ describe Loader::SalesforceSoap do
       { Id: '2', Custom__c: 'something', Merge_Id: '20' }
     ]
 
-    expect(soapforce_client).to receive(:merge).twice
+    expect(soapforce_client).to receive(:merge!).twice
+    loader.load(data)
+  end
+
+  it 'excludes blank data fields from the merge command' do
+    data = [
+      { Id: '1234', Custom__c: '', Merge_Id: '5678' }
+    ]
+
+    expect(soapforce_client).to receive(:merge!) do
+      [
+        :Contact,
+        {
+          Id: '1234'
+        },
+        ['5678']
+      ]
+    end
+
     loader.load(data)
   end
 
@@ -76,5 +94,4 @@ describe Loader::SalesforceSoap do
 
     expect { loader.load(data) }.to raise_error KeyError
   end
-
 end


### PR DESCRIPTION
- Use `merge!` instead of `merge` so that any merge errors will raise an exception
- Exclude blank fields from `merge` to improve performance and resolve blank-date issues
- Fix error with calling the upsert method on the SfBulkDelete class