### PR TITLE
FIX - Subtransforms map to the correct source index

### DIFF
--- a/lib/remi/source_to_target_map/map.rb
+++ b/lib/remi/source_to_target_map/map.rb
@@ -129,10 +129,12 @@ module Remi
       # Private: Converts the transformed data into vectors in the target dataframe.
       def map_to_target_df
         index = @target_df.index.size > 0 ? @target_df.index : @source_df.index
+
         result_hash_of_arrays.each do |vector, values|
           @target_df[vector] = Daru::Vector.new(values, index: index)
         end
 
+        @target_df.index = index
         @target_df
       end
 


### PR DESCRIPTION
This bug affected cases where the source and target of
a subtransform referred to the same subject in the parent job.
In these cases, if the index was modified (e.g., by sorting or joining), the
values that would get put back onto the parent job datasubject could be
out of order.