### PR TITLE
DE-1127 - Prevent cucumber tests from attempting to reach out to AWS

### DIFF
--- a/features/s3_file_target_job.feature
+++ b/features/s3_file_target_job.feature
@@ -1,0 +1,10 @@
+Feature: Tests targets that are S3 Files.
+
+  Background:
+    Given the job is 'S3 File Target'
+    And the job target 'Some File'
+
+  Scenario: Defining the remote path.
+    Given the target 'Some File'
+    Then the file is uploaded to the S3 bucket "the-big-one"
+    And the file is uploaded to the remote path "some_file_*Today: %Y%m%d*.csv"

--- a/features/step_definitions/remi_step.rb
+++ b/features/step_definitions/remi_step.rb
@@ -69,6 +69,14 @@ Then /^the file is uploaded to the remote path "([^"]+)"$/ do |remote_path|
   expect(@brt.target.data_subject.loaders.map(&:remote_path)).to include expected_path
 end
 
+Then /^the file is uploaded to the S3 bucket "([^"]+)"$/ do |bucket_name|
+  expected_bucket_name = Remi::Testing::BusinessRules::ParseFormula.parse(bucket_name)
+  bucket_names = @brt.target.data_subject.loaders.map do |loader|
+    loader.bucket_name if loader.respond_to? :bucket_name
+  end
+  expect(bucket_names).to include expected_bucket_name
+end
+
 ## CSV Options
 
 Given /^the (source|target) file is delimited with a (\w+)$/ do |st, delimiter|

--- a/jobs/s3_file_target_job.rb
+++ b/jobs/s3_file_target_job.rb
@@ -1,0 +1,23 @@
+require_relative 'all_jobs_shared'
+require 'aws-sdk'
+
+class S3FileTargetJob < Remi::Job
+  target :some_file do
+    encoder Remi::Encoder::CsvFile.new
+    loader Remi::Loader::S3File.new(
+      credentials: {
+        aws_access_key_id: 'blort',
+        aws_secret_access_key: 'blerg',
+        region: 'us-west-2'
+      },
+      kms_opt: {
+        ciphertext: 'blergity'
+      },
+      bucket: 'the-big-one',
+      remote_path: "some_file_#{DateTime.current.strftime('%Y%m%d')}.csv"
+    )
+  end
+
+  transform :main do
+  end
+end


### PR DESCRIPTION
Moves the kms_init method to the actual load operation, which isn't called
in cucumber tests.

Feature tests.  Always....