### PR TITLE
FIX - Make sure that empty PG and SF dataframes have fields

### DIFF
--- a/lib/remi/data_subjects/postgres.rb
+++ b/lib/remi/data_subjects/postgres.rb
@@ -97,7 +97,8 @@ module Remi
       # After converting to DF, clear the PG results to save memory.
       postgres_extract.data.clear
 
-      Remi::DataFrame.create(:daru, hash_array, order: hash_array.keys)
+      df_fields = fields.keys | hash_array.keys
+      Remi::DataFrame.create(:daru, hash_array, order: df_fields)
     end
   end
 

--- a/lib/remi/data_subjects/salesforce.rb
+++ b/lib/remi/data_subjects/salesforce.rb
@@ -122,7 +122,8 @@ module Remi
         batch['response'] = nil
       end
 
-      Remi::DataFrame.create(:daru, hash_array, order: hash_array.keys)
+      df_fields = fields.keys | hash_array.keys
+      Remi::DataFrame.create(:daru, hash_array, order: df_fields)
     end
   end
 


### PR DESCRIPTION
If a postgres or Salesforce result had no records, the dataframes
had no fields.  This was causing unexpected errors in jobs.  Now,
whenever this happens, the result will have the fields defined in
the data subject.