### PR TITLE
DE-1090 - Allow users to define values that don't get type enforced

### DIFF
--- a/lib/remi/transform.rb
+++ b/lib/remi/transform.rb
@@ -522,6 +522,8 @@ module Remi
       def transform(value)
         if value.blank? && type != :json
           blank_handler(value)
+        elsif value.respond_to?(:enforce_types?) && !value.enforce_types?
+          value
         else
           case type
           when :string

--- a/spec/data_subject_spec.rb
+++ b/spec/data_subject_spec.rb
@@ -123,6 +123,17 @@ describe DataSubject do
       data_subject.enforce_types
       expect(dataframe.vectors.to_a).to eq [:my_date]
     end
+
+    it 'does not enforce types if a enforce_types? is false' do
+      data_subject.df[:my_date].recode { |v|
+        def v.enforce_types?
+          false
+        end
+      }
+
+      data_subject.enforce_types
+      expect(data_subject.df[:my_date].to_a).to eq ['10/21/2015']
+    end
   end
 end
 


### PR DESCRIPTION
We needed this to support cases where empty data type besides nil.  For example,
suppose we have a data target that is mostly expecting dates in a particular field.
If we don't want the field to update, we can't use nil, because that might indicate that
the field should be populated with nil.  Instead, we can define a custom class that
the data target can detect and send a special message to the target to indicate that
there is to be no update of the existing value.